### PR TITLE
chore: update `.zshrc` configuration and plugins

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,6 +1,3 @@
-autoload -Uz compinit
-compinit
-
 # Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.
 # Initialization code that may require console input (password prompts, [y/n]
 # confirmations, etc.) must go above this block; everything else may go below.
@@ -9,17 +6,17 @@ if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]
 fi
 
 # If you come from bash you might have to change your $PATH.
-# export PATH=$HOME/bin:/usr/local/bin:$PATH
+# export PATH=$HOME/bin:$HOME/.local/bin:/usr/local/bin:$PATH
 
-# Path to your oh-my-zsh installation.
+# Path to your Oh My Zsh installation.
 export ZSH="$HOME/.oh-my-zsh"
 
 # Set name of the theme to load --- if set to "random", it will
-# load a random theme each time oh-my-zsh is loaded, in which case,
+# load a random theme each time Oh My Zsh is loaded, in which case,
 # to know which specific one was loaded, run: echo $RANDOM_THEME
 # See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
-#ZSH_THEME="robbyrussell"
-ZSH_THEME="powerlevel10k/powerlevel10k"
+#ZSH_THEME="powerlevel10k/powerlevel10k"
+
 # Set list of themes to pick from when loading at random
 # Setting this variable when ZSH_THEME=random will cause zsh to load
 # a theme from this variable instead of looking in $ZSH/themes/
@@ -83,10 +80,8 @@ ZSH_THEME="powerlevel10k/powerlevel10k"
 plugins=(
   git
   git-open
-  zsh-autosuggestions
   kubectl
   docker
-  zsh-syntax-highlighting
   colored-man-pages
   extract
   cp
@@ -95,6 +90,10 @@ plugins=(
   git-auto-fetch
   aliases
   autojump
+  zsh-autosuggestions
+  zsh-syntax-highlighting
+  fast-syntax-highlighting
+  zsh-autocomplete
 )
 
 source $ZSH/oh-my-zsh.sh
@@ -110,61 +109,61 @@ source $ZSH/oh-my-zsh.sh
 # if [[ -n $SSH_CONNECTION ]]; then
 #   export EDITOR='vim'
 # else
-#   export EDITOR='mvim'
+#   export EDITOR='nvim'
 # fi
 
 # Compilation flags
-# export ARCHFLAGS="-arch x86_64"
+# export ARCHFLAGS="-arch $(uname -m)"
 
-# Set personal aliases, overriding those provided by oh-my-zsh libs,
-# plugins, and themes. Aliases can be placed here, though oh-my-zsh
-# users are encouraged to define aliases within the ZSH_CUSTOM folder.
+# Set personal aliases, overriding those provided by Oh My Zsh libs,
+# plugins, and themes. Aliases can be placed here, though Oh My Zsh
+# users are encouraged to define aliases within a top-level file in
+# the $ZSH_CUSTOM folder, with .zsh extension. Examples:
+# - $ZSH_CUSTOM/aliases.zsh
+# - $ZSH_CUSTOM/macos.zsh
 # For a full list of active aliases, run `alias`.
 #
 # Example aliases
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
-
 alias CW="date +%V"
-
-export NVM_DIR="$HOME/.nvm"
-[ -s "/usr/local/opt/nvm/nvm.sh" ] && \. "/usr/local/opt/nvm/nvm.sh"  # This loads nvm
-[ -s "/usr/local/opt/nvm/etc/bash_completion.d/nvm" ] && \. "/usr/local/opt/nvm/etc/bash_completion.d/nvm"  # This loads nvm bash_completion
-
-# Java
-export GRAALVM_HOME="$HOME/Library/Java/JavaVirtualMachines/graalvm-ce-17/Contents/Home/bin"
-export PATH="$HOME/Library/Java/JavaVirtualMachines/graalvm-ce-17/Contents/Home/bin:$PATH"
-export JAVA_HOME="$HOME/Library/Java/JavaVirtualMachines/graalvm-ce-17/Contents/Home"
-
 # go
 export GONOPROXY=""
 export GOPRIVATE=""
 export GOPROXY="https://goproxy.cn,direct"
 export GO111MODULE=on
 export GIT_TERMINAL_PROMPT=1
-export GOPATH="/Users/spencercjh/go"
 export CGO_ENABLED=0
-export GOPATH="$HOME/go"
-export PATH="$PATH:$GOPATH/bin"
+# goenv
+export GOENV_ROOT="$HOME/.goenv"
+export PATH="$GOENV_ROOT/bin:$PATH"
+eval "$(goenv init -)"
 export PATH="$GOROOT/bin:$PATH"
-
+export PATH="$PATH:$GOPATH/bin"
+# golangci-lint
+source <(golangci-lint completion zsh)
 # kubectx
 alias kctx='kubectx'
 alias kns='kubens'
-#kube-ps1
-export PROMPT='$(kube_ps1)'$PROMPT # or RPROMPT='$(kube_ps1)'
-export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
+# kube-ps1
+source "/opt/homebrew/opt/kube-ps1/share/kube-ps1.sh"
+PS1='$(kube_ps1)'$PS1
 # kubectl completion
 source <(kubectl completion zsh)
 export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
-
-# podman
-#alias docker='podman'
-
+# helm completion
+source <(helm completion zsh)
+# pyenv
+export PYENV_ROOT="$HOME/.pyenv"
+[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
+eval "$(pyenv init - zsh)"
+# nvm
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 
-source /opt/homebrew/share/powerlevel10k/powerlevel10k.zsh-theme
-
 # autojump
-[ -f /usr/local/etc/profile.d/autojump.sh ] && . /usr/local/etc/profile.d/autojump.sh
+  [ -f /opt/homebrew/etc/profile.d/autojump.sh ] && . /opt/homebrew/etc/profile.d/autojump.sh
+source /opt/homebrew/share/powerlevel10k/powerlevel10k.zsh-theme


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Reorganized and enhanced `.zshrc` plugin configuration
  - Added `fast-syntax-highlighting` and `zsh-autocomplete` plugins
  - Moved `zsh-autosuggestions` and `zsh-syntax-highlighting` to end of plugin list

- Improved language, comments, and documentation throughout
  - Clarified Oh My Zsh references and alias instructions
  - Updated editor and architecture flag examples

- Enhanced environment and tool initialization
  - Switched to `goenv` for Go version management
  - Added completions for `golangci-lint` and `helm`
  - Improved `pyenv` and `nvm` initialization
  - Updated `kube-ps1` and `autojump` sourcing for Homebrew paths

- Cleaned up and modernized path and alias settings
  - Updated `$PATH` and removed redundant or outdated lines


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.zshrc</strong><dd><code>Major refactor and enhancement of .zshrc configuration</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.zshrc

<li>Added new plugins: <code>fast-syntax-highlighting</code>, <code>zsh-autocomplete</code><br> <li> Improved and clarified comments and documentation<br> <li> Enhanced Go, Python, Node, and Kubernetes tool initialization<br> <li> Updated path, alias, and sourcing logic for modern setups


</details>


  </td>
  <td><a href="https://github.com/spencercjh/dotfile/pull/2/files#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383">+40/-41</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>